### PR TITLE
Emit Buffer data direct from node-microphone

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,9 @@ class Microphone extends EventEmitter {
             this.ps.stderr.on('data', (info) => {
                 this.emit('info', info);
             })
+            this.ps.stdout.on('data', (data) => {
+                this.emit('data', data)
+            })
             return this.ps.stdout;
            
         }


### PR DESCRIPTION
Hi, this is a super basic PR, it creates an event emitter on microphone data that sends the raw buffer out of node-microphone via an event emitter. It's super useful in cases like mine of node-carplay. It allows me to add format data to the buffer, and then pass on. Without this everytime I start/stop the microphone, I need to create a new stream, and re-instantiate the event listeners to that stream.